### PR TITLE
Added challenge descriptions to the feed items, and some light re-factoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+
+# Usage
+## Supported parameters
+- `track`: optional (default = "all").  valid values are {"all", "develop", "design", "data"}.
+Two other deprecated parameters are also accepted (for backwards compatibility) but are disregarded if `track` is supplied: `type`, `contestType`
+- `list`: optional (default = "active").  valid values are {"active", "open", "past", "upcoming"}
+
+## Parameters supported only for design/develop tracks
+- `challengeType` optional, no default.  Valid only for develop and design tracks
+- `technologies`
+- `platforms`
+
+## Examples
+/challenges/feed?track=design&list=upcoming
+/challenges/feed?track=all&list=upcoming
+/challenges/feed?track=develop&list=open&technologies=JavaScript
+
+# Running
+## Underlying APIs used
+http://docs.tcapi.apiary.io/#softwarechallenges
+
+## Required ENV params
+- API_HOST || "http://api.topcoder.com"
+
+to support the RSS headers:
+
+- FEED_TITLE
+- FEED_DESC
+- FEED_URL
+- FEED_SITE_URL
+
+## Optional ENV params
+- CACHE_TIME || 5 //in minutes
+- REQUEST_TIMEOUT || 25 //inbound timeout (seconds)
+- API_TIMEOUT || 20 //outbound TC API timeout (seconds)
+- PAGE_SIZE || 51 // page size sent to TC API
+- DESC_TRUNC_LENGTH || 500 // number of characters to limit challenge description included in feed

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -8,12 +8,12 @@
 /* jslint node: true */
 /* jslint nomen: true */
 
-'use strict';
+"use strict";
 
 /*!
  * Module dependencies
  */
-require('dotenv').load();
+require("dotenv").load();
 
 
 /**
@@ -22,9 +22,12 @@ require('dotenv').load();
 module.exports = {
     // Environment
     PORT: process.env.PORT || 3333,
-    CACHE_TIME: process.env.CACHE_TIME,
-    API_TIMEOUT: process.env.API_TIMEOUT,
-    API_HOST: process.env.API_HOST,
+    CACHE_TIME: process.env.CACHE_TIME || 5, //minutes
+    REQUEST_TIMEOUT: process.env.REQUEST_TIMEOUT || 25, //inbound timeout in seconds
+    API_TIMEOUT: process.env.API_TIMEOUT || 20, //outbound TC API timeout in seconds
+    API_HOST: process.env.API_HOST || "http://api.topcoder.com",
+    PAGE_SIZE: process.env.PAGE_SIZE || 51,
+    DESC_TRUNC_LENGTH: process.env.DESC_TRUNC_LENGTH || 500,
     FEED_OPTIONS: {
         // See https://github.com/dylang/node-rss#feedoptions
         // for possible options and more info how to use them.
@@ -39,11 +42,10 @@ module.exports = {
     //
     // Whitelist of all query parameters supported by the endpoint.
     // Not listed here will be filtered out.
-    queryParamsSupported: ['contestType', 'list', 'challengeType', 'platforms', 'technologies'],
-    // Allowed values for the `contestType` query parameter.
-    validTracks: ['design', 'develop', 'data', 'all'],
+    queryParamsSupported: ["type", "track", "contestType", "list", "challengeType", "platforms", "technologies"],
+    // Allowed values for the `type` query parameter. (note: all is omitted here on purpose)
+    validTracks: ["design", "develop", "data"],
     // Allowed values for the `list` query parameter.
-    validLists: ['active', 'past', 'upcoming'],
+    validLists: ["open", "active", "past", "upcoming"]
 
-    xmlMeta: '<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" media="screen" href="https://www.topcoder.com/wp-content/themes/tcs-responsive/css/rss2full.xsl"?>'
 };

--- a/index.js
+++ b/index.js
@@ -8,24 +8,30 @@
 /* jslint node: true */
 /* jslint nomen: true */
 
-'use strict';
+"use strict";
 
 
 /*!
  * Module dependencies
  */
-var config = require('./config/defaults'),
-    express = require('express'),
+var config = require("./config/defaults"),
+    express = require("express"),
+    timeout = require("connect-timeout"),
     app = express(),
-    feed = require('./utils/feed'),
-    log = require('./utils/logger');
+    feed = require("./utils/feed"),
+    log = require("./utils/logger");
 
+// Set a global request timeout
+app.use(timeout(config.REQUEST_TIMEOUT + "s"));
 
 // Define the endpoint.
-app.get('/challenges/feed', function (req, res) {
-    return feed(req, res);
+app.get("/challenges/feed", feed);
+
+// Generic error hanndler (primarily for timeout)
+app.use(function (err, req, res, next) {
+    res.status(err.status || 500).send(err.message || "Unexpected Error");
 });
 
 // Listen for connections.
 app.listen(config.PORT);
-log.info('Service listening on port:', config.PORT);
+log.info("Service listening on port:", config.PORT);

--- a/package.json
+++ b/package.json
@@ -10,10 +10,15 @@
   "dependencies": {
     "dotenv": "^0.4.0",
     "express": "^4.10.6",
-    "lodash": "^2.4.1",
+    "connect-timeout": "~1.6",
+    "lodash": "~3.5",
+    "async": "~0.9",
     "memory-cache": "0.0.5",
-    "request": "^2.51.0",
+    "request": "~2.53",
     "rss": "^1.0.1",
-    "winston": "^0.8.3"
+    "winston": "^0.8.3",
+    "sanitize-html": "~1.6",
+    "html-truncate": "~1.0",
+    "moment": "~2.9"
   }
 }

--- a/utils/feed.js
+++ b/utils/feed.js
@@ -8,258 +8,187 @@
 /* jslint node: true */
 /* jslint nomen: true */
 
-'use strict';
-
+"use strict";
 
 /*!
  * Module dependencies
  */
-var config = require('../config/defaults'),
-    RSS = require('rss'),
-    _ = require('lodash'),
-    request = require('request'),
-    log = require('./logger'),
-    cache = require('./cache');
-
+var _ = require("lodash"),
+    async = require("async");
+    
+var config = require("../config/defaults"),
+    log = require("./logger"),
+    cache = require("./cache"),
+    rssUtil = require("./rssutil.js"),
+    tcapi = require("./tcapi");
+    
+/**
+ * Default error response XML
+ */
+var _invalidRequestXML = '<?xml version="1.0" encoding="UTF-8"?><text><para>Invalid parameters</para></text>';
 
 /**
- *
+ * Query normalization: whitelisting, defaulting, etc
+ * Both the "track" and "contestType" (for backwards compat) paramaters are synomyms to "type" 
+ * which is used for two purposes:
+ * It is passed in to the /v2/challenges API verbatim, 
+ * but also the "all" and "data" values hold special control flow meaning
+ * A value can be passed in any of these three fields, but precedence is applied
+ * 
+ * This function also applies a whitelist to protect from unsupported query params,
+ * as well as defaulting a "list" value of "active" if none is supplied
+ * 
+ * @private
+ * @param {object} query
+ * @return {object}
+ */
+var _normalizeQuery = function (query) {
+    // whitelisting
+    var normalizedQuery = _.pick(query, config.queryParamsSupported);
+    
+    // type
+    normalizedQuery.type = normalizedQuery.type || normalizedQuery.track || normalizedQuery.contestType || "all";
+    normalizedQuery = _.omit(normalizedQuery, ["contestType", "track"]);
+    
+    // list: default and collapse
+    if (!_.has(normalizedQuery, "list") || _.isEmpty(normalizedQuery.list)) {
+        normalizedQuery.list = "active";
+    } else if (_.isArray(normalizedQuery.list) && _.size(normalizedQuery.list > 1)) {
+        normalizedQuery.list = _.first(normalizedQuery.list);
+    }
+    
+    return normalizedQuery;
+};
+
+/**
+ * Handle the request for challenge/feed RSS XML
  *
  * @param {Object} req Express's request object
  * @param {Object} res Express's response object
+ * @param {function} next 
  * @api public
  */
-module.exports = function (req, res) {
+module.exports = function (req, res, next) {
 
-    var
-    // Let's pick and work with only the supported query parameters.
-    // Needed to secure us from other and protect the cache indexing.
-        whiteListedQuery = _.pick(req.query, config.queryParamsSupported),
-        // Serialize the query as it is used for key indexing the cache.
-        serializedQuery = JSON.stringify(whiteListedQuery),
-        // Flag if the request was processed.
-        processed = false,
-        // Flag if the request timeout.
-        timeout = false,
-        // The rss content generator.
-        feed = new RSS(config.FEED_OPTIONS);
+    var normalizedQuery = _normalizeQuery(req.query),
+        serializedQuery = JSON.stringify(normalizedQuery);
 
-    log.info('Processing request for query: %s', serializedQuery);
-
-    /*!
-     * API timeout handler function.
+    log.info("Processing request for query: %s", serializedQuery);
+    
+    /**
+     * Send the response only if it has not already timedout
+     * 
+     * @private
+     * @param {string | object} body
+     * @param {number=} code optional status code
+     * @param {string=} mimeType optional mime type
      */
-    _.delay(function () {
-        // Make sure the request is still pending.
-        // Otherwise do nothing.
-        if (!processed) {
-            timeout = true;
-            log.info('API timeout triggered after %d seconds', config.API_TIMEOUT);
-            res.status(202).send('');
+    var _sendResponse = function (body, code, mimeType) {
+        if (req.timedout) {
+            next({timeout: true, message:"request timed out before feed could be sent as response"});
+        } else {
+            if (code) {
+                res.status(code);
+            }
+            if (mimeType) {
+                res.type("xml");
+            }
+            res.send(body);
         }
-    }, config.API_TIMEOUT * 1000);
+    };
+        
+    /**
+     * Given an initialize array of TC challenge data, 
+     * build the feed items, and add the XML to the response and cache
+     * 
+     * @private
+     * @param {Array.<object>} data an array of data items returned from the TC API
+     */
+    var _returnFeed = function (data) {
+        var rssXML = rssUtil.buildFeedXML(data);
+        
+        _sendResponse(rssXML, null, "xml");
+        
+        cache.put(serializedQuery, rssXML);
+        log.info("Request with query %s processed", serializedQuery);
+    };
 
     /**
-     * HTTP[S] request helper function. Reduces boilerplate code.
-     *
-     * @param {String} url The url to request
-     * @param {Function} fn Callback
-     * @api private
+     * Generic Error Handler
      */
-    function requestFromTC_API(url, fn) {
-        request({
-            url: url,
-            json: true,
-            //timeout: config.API_TIMEOUT * 1000
-        }, function (err, rsp, body) {
-            // Do nothing if timeout alredy triggered.
-            if (err || rsp.statusCode !== 200) {
-                log.error('Request FAILED.', err || rsp.statusCode);
-                res.status((rsp && rsp.statusCode) || 500).end();
-                processed = true;
-            } else {
-                log.info('Request OK.', rsp.statusCode);
-                fn(rsp, body);
-            }
-        });
-    }
-
-    // Setting the appropriate Content-Type of the response.
-    res.set('Content-Type', 'text/xml; charset=utf-8');
+    var _returnError = function (message, err) {
+        log.error(message, err);
+        _sendResponse("Internal Error while building feed", 500);
+    };
 
     // Check if serving from cache is possible.
     // If so serve the cached response otherwise make API call.
     var cached_rsp = cache.get(serializedQuery);
     if (cached_rsp) {
         // Cache available.
-        log.info('Serving response from cache...');
-        res.send(cached_rsp);
-        processed = true;
-        // Notify.
-        log.info('Request with query %s processed', serializedQuery);
+        log.info("Serving response from cache...");
+        _sendResponse(cached_rsp, null, "xml");
     } else {
         // Cache not available.
-        log.info('No cached response available. Using TC API...');
+        log.info("No cached response available. Using TC API...");
 
         // Default -> will return all challenges including `data science`.
-        if (_.isEmpty(whiteListedQuery) || !whiteListedQuery.contestType || whiteListedQuery.contestType == 'all') {
-            var url_challenges = config.API_HOST + '/v2/challenges?pageIndex=1&pageSize=2147483647',
-                url_data = config.API_HOST + '/v2/data/marathon/challenges?pageIndex=1&pageSize=2147483647',
-                combined;
-
-            if (whiteListedQuery.list) {
-                url_challenges += '&listType=' + whiteListedQuery.list;
-                url_data += '&listType=' + whiteListedQuery.list;
-            }
-
-            log.info('GET %s', url_challenges);
-
-            requestFromTC_API(url_challenges, function (challenges_rsp, challenges_body) {
-                // Store the results returned.
-                combined = challenges_body.data;
-
-                // To get the data challenges too we need 2nd call to the `/data` endpoint.
-                // After that we serve combined results.
-                log.info('GET %s', url_data);
-
-                requestFromTC_API(url_data, function (data_rsp, data_body) {
-                    log.info('Combining, sorting and building feed from %d challenges', combined.length + data_body.data.length);
-
-                    // Combine
-                    _.each(data_body.data, function (data_challenge) {
-                        // The `/data` endpoint uses different response structure
-                        // so we need to manually translate.
-                        combined.push({
-                            challengeName: data_challenge.fullName,
-                            problemId: data_challenge.problemId,
-                            roundId: data_challenge.roundId,
-                            postingDate: data_challenge.startDate
-                        });
-                    });
-
-                    // Sort and iterate data to create feed items.
-                    _.chain(combined)
-                        .sortBy('postingDate')
-                        .reverse()
-                        .each(function (challenge) {
-                            feed.item({
-                                title: challenge.challengeName,
-                                url: (challenge.problemId ?
-                                    ('https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=' + challenge.roundId + '&pm=' + challenge.problemId) :
-                                    ('https://www.topcoder.com/challenge-details/' + challenge.challengeId + '/?type=' + challenge.challengeCommunity)),
-                                guid: challenge.challengeId || challenge.problemId,
-                                date: challenge.postingDate
-                            });
-                        });
-                    // Get the XML
-                    var feed_body = feed.xml();
-                    // Respond.
-                    if (!timeout) {
-                        res.send(feed_body);
-                    } else {
-                        log.info('Storing response in cache...');
-                    }
-                    // Update cache and done flag.
-                    cache.put(serializedQuery, feed_body);
-                    processed = true;
-                    // Notify.
-                    log.info('Request with query %s processed', serializedQuery);
-                });
+        // The "list" query param will be honored, but platforms and tecnologies,
+        // but technologies and platforms are not supported in "all" mode
+        if (_.isEmpty(normalizedQuery) || _.isEmpty(normalizedQuery.type) || normalizedQuery.type === "all") {
+            async.parallel([
+                function(callback){
+                    tcapi.getStandardChallenges(normalizedQuery.list, null, callback);
+                },
+                function(callback){
+                    tcapi.getDataScienceChallenges({listType: normalizedQuery.list}, callback);
+                }
+            ],
+            // combine the results
+            function(err, results) {
+                if (err) {
+                    _returnError("Failed to retrive COMBINED challenges from TC", err);
+                    return true;
+                } else {
+                    _returnFeed(results[0].data.concat(results[1].data));                    
+                }
             });
+            
         } else {
             // Some query parameters present.
             // To be able to decide what to serve we need `type` and `listType` to be valid and present.
-            // Let's validate them.
-            if (_.contains(config.validTracks, whiteListedQuery.contestType) && _.contains(config.validLists, whiteListedQuery.list)) {
+            if (_.contains(config.validTracks, normalizedQuery.type) &&
+                _.contains(config.validLists, normalizedQuery.list)) {
+                
                 // Valid and present.
                 // Data challenges need different handling again.
-                if (whiteListedQuery.contestType == 'data') {
-                    // Handle `data science` requests.
-                    var url_marathon = config.API_HOST + '/v2/data/marathon/challenges?listType=' + whiteListedQuery.list + '&pageIndex=1&pageSize=2147483647';
-
-                    log.info('GET %s', url_marathon);
-
-                    requestFromTC_API(url_marathon, function (marathon_rsp, marathon_body) {
-                        log.info('Sorting and building feed from %d challenges', marathon_body.data.length);
-
-                        // Sort and iterate data to create feed items.
-                        _.chain(marathon_body.data)
-                            .sortBy('startDate')
-                            .reverse()
-                            .each(function (challenge) {
-                                feed.item({
-                                    title: challenge.fullName,
-                                    url: 'https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=' + challenge.roundId + '&pm=' + challenge.problemId,
-                                    guid: challenge.problemId,
-                                    date: challenge.startDate
-                                });
-                            });
-                        // Get the XML
-                        var feed_body = feed.xml();
-                        // Respond.
-                        if (!timeout) {
-                            res.send(feed_body);
+                if (normalizedQuery.type == "data") {
+                    tcapi.getDataScienceChallenges({listType: normalizedQuery.list}, function (err, body) {
+                        if (err) {
+                            _returnError("Failed to retrieve data challenges from TC", err);
+                            return true;
                         } else {
-                            log.info('Storing response in cache...');
+                            _returnFeed(body.data);                    
                         }
-                        // Update cache and done flag.
-                        cache.put(serializedQuery, feed_body);
-                        processed = true;
-                        // Notify.
-                        log.info('Request with query %s processed', serializedQuery);
                     });
                 } else {
                     // All other types.
-                    var url_others = config.API_HOST + '/v2/challenges/' + whiteListedQuery.list +
-                        '?type=' + whiteListedQuery.contestType +
-                        '&pageIndex=1&pageSize=2147483647' +
-                        (whiteListedQuery.challengeType ? ('&challengeType=' + whiteListedQuery.challengeType) : '') +
-                        (whiteListedQuery.technologies ? ('&technologies=' + whiteListedQuery.technologies) : '') +
-                        (whiteListedQuery.platforms ? ('&platforms=' + whiteListedQuery.platforms) : '');
-
-                    log.info('GET %s', url_others);
-
-                    requestFromTC_API(url_others, function (others_rsp, others_body) {
-                        log.info('Sorting and building feed from %d challenges', others_body.data.length);
-
-                        // Sort and iterate data to create feed items.
-                        _.chain(others_body.data)
-                            .sortBy('registrationStartDate')
-                            .reverse()
-                            .each(function (challenge) {
-                                feed.item({
-                                    title: challenge.challengeName,
-                                    url: 'https://www.topcoder.com/challenge-details/' + challenge.challengeId + '/?type=' + challenge.challengeCommunity,
-                                    guid: challenge.challengeId,
-                                    date: challenge.registrationStartDate
-                                });
-                            });
-                        // Get the XML
-                        var feed_body = feed.xml();
-                        // Respond.
-                        if (!timeout) {
-                            res.send(feed_body);
+                    var query = _.omit(normalizedQuery, "list");
+                    tcapi.getStandardChallenges(normalizedQuery.list, query, function (err, body) {
+                        if (err) {
+                            _returnError("Failed to retrieve standard challenges from TC", err);
+                            return true;
                         } else {
-                            log.info('Storing response in cache...');
+                            _returnFeed(body.data);                    
                         }
-                        // Update cache and done flag.
-                        cache.put(serializedQuery, feed_body);
-                        processed = true;
-                        // Notify.
-                        log.info('Request with query %s processed', serializedQuery);
                     });
                 }
             } else {
                 // Not valid.
-                res.status(400).send(
-                    '<?xml version="1.0" encoding="UTF-8"?>' +
-                    '<text>' +
-                    '<para>Invalid parameters</para>' +
-                    '</text>'
-                );
-                processed = true;
+                _sendResponse(_invalidRequestXML, 400, "xml");
                 // Notify.
-                log.error('Request with query %s handled but is invalid', serializedQuery);
+                log.error("Request with query %s handled but is invalid", serializedQuery);
+                return true;
             }
         }
     }

--- a/utils/rssutil.js
+++ b/utils/rssutil.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2014 TopCoder Inc., All Rights Reserved.
+ *
+ * @version 1.0
+ * @author TCCODER
+ */
+
+/* jslint node: true */
+/* jslint nomen: true */
+
+"use strict";
+
+var RSS = require("rss"),
+    _ = require("lodash"),
+    moment = require("moment"),
+    htmlSanitize = require("sanitize-html"),
+    htmlTruncate = require("html-truncate");
+
+var config = require("../config/defaults");
+    
+/**
+ * Default Date Format
+ */
+var _dateFormat = function (date) {
+    return moment(date).format("YYYY-MM-DD HH:mm Z");
+};
+
+/**
+ * Truncate given HTML in a "tag safe" way, but first sanitize it to get rid of all but a core set of HTML tags
+ */
+var _truncAndSanitizeHtml = function (html, truncLength) {
+    return htmlTruncate(htmlSanitize(html), truncLength);
+};
+    
+/**
+ * Do the heavy lifting of formatting challenge data into something that can be jammed into an RSS feed
+ */
+var _buildChallengeInfoBlurb = function (challenge) {
+    var html = "",
+        templateString = "<div><%- key %>: <%- value %></div>",
+        template = _.template(templateString);
+    
+    if (challenge.detailedRequirements) {
+        html += _truncAndSanitizeHtml(challenge.detailedRequirements, config.DESC_TRUNC_LENGTH);
+        html += "<br />";
+    }
+    if (challenge.platforms) {
+        html += template({key: "Platforms", value: challenge.platforms.join(" / ")});
+    }
+    if (challenge.technologies) {
+        html += template({key: "Technologies", value: challenge.technologies.join(" / ")});
+    }
+    if (challenge.firstPlacePrize || challenge.totalPrize) {
+        html += template({key: "Prize", value: challenge.totalPrize + " (" + challenge.firstPlacePrize + ")"});
+    }
+    if (challenge.registrationStartDate || challenge.registrationEndDate) {
+        html += template({key: "Registration Period", 
+            value: _dateFormat(challenge.registrationStartDate) + " - " + _dateFormat(challenge.registrationEndDate)});
+    }
+    if (challenge.registrationOpen) {
+        html += template({key: "Open for registration", value: challenge.registrationOpen});
+    }
+    if (challenge.submissionEndDate) {
+        html += template({key: "Submissions Due", value: _dateFormat(challenge.submissionEndDate)});
+    }
+    if (challenge.challengeType || challenge.challengeCommunity) {
+        html += template({key: "Type", value: challenge.challengeType + " / " + challenge.challengeCommunity });
+    }
+        
+    return html;
+ 
+};
+
+/**
+ * Given an array of challenges, build an RSS feed as XML data
+ * 
+ * @param {Array.<Challenge>} challenges
+ * @return {XML} feed
+ */
+exports.buildFeedXML = function (challenges) {
+    
+    var feed = new RSS(config.FEED_OPTIONS);
+
+    // Sort and iterate challenges to create feed items.
+    _.chain(challenges)
+            .sortBy("registrationStartDate")
+            .reverse()
+            .forEach(function (challenge) {
+                feed.item({
+                    title: challenge.challengeName,
+                    url: (challenge.problemId ?
+                        ("https://community.topcoder.com/longcontest/?module=ViewProblemStatement&rd=" + challenge.roundId + "&pm=" + challenge.problemId) :
+                        ("https://www.topcoder.com/challenge-details/" + challenge.challengeId + "/?type=" + challenge.challengeCommunity)),
+                    guid: challenge.challengeId || challenge.problemId,
+                    date: challenge.registrationStartDate,
+                    description: _buildChallengeInfoBlurb(challenge)
+                });
+            })
+            .commit();  // for the lodash chain to finalize
+        
+    return feed.xml();
+};

--- a/utils/tcapi.js
+++ b/utils/tcapi.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2014 TopCoder Inc., All Rights Reserved.
+ *
+ * @version 1.0
+ * @author TCCODER
+ */
+
+/* jslint node: true */
+/* jslint nomen: true */
+
+"use strict";
+
+
+/*!
+ * Module dependencies
+ */
+var config = require("../config/defaults"),
+    _ = require("lodash"),
+    async = require("async"),
+    request = require("request"),
+    log = require("./logger"),
+    cache = require("./cache");
+
+/**
+ * base URLs for TC API
+ */
+var url_standardChallenges = config.API_HOST + "/v2/challenges",
+    url_dataScience = config.API_HOST + "/v2/data/marathon/challenges",
+    defaultQs = {
+        pageIndex: 1,
+        pageSize: config.PAGE_SIZE
+    };
+    
+/**
+ * HTTP[S] request helper function
+ *
+ * @private
+ * @param {string} url The url to request
+ * @param {object} query 
+ * @param {function} fn Callback
+ */
+var requestFromTC_API = function (url, query, callback) {
+    log.info("Calling API %s %j", url, query);
+    
+    var cachedKey = "TC" + url + JSON.stringify(query),
+        cachedResponse = cache.get(cachedKey);
+        
+    if (cachedResponse) {
+        // Cache available.
+        log.info("Serving response from cache...");
+        callback(null, cachedResponse);
+    } else {
+        //request.debug = true;
+        request({
+            url: url,
+            qs: query,
+            useQuerystring: true,
+            json: true,
+            timeout: config.API_TIMEOUT * 1000
+        }, function (err, rsp, body) {
+            if (err || rsp.statusCode !== 200) {
+                log.error('Request FAILED.', err || rsp.statusCode);
+                callback(err || "HTTP error " + rsp.statusCode);
+            } else {
+                log.info('Request OK.', rsp.statusCode);
+                cache.put(cachedKey, body);
+                callback(null, body);
+            }
+        });
+    }
+}
+
+
+/**
+ * Performs a cache-first request to the topcoder API
+ *
+ * @param {string} list supported lists: "open", "active", "past", "upcoming"
+ * @param {object} query 
+ * @param {funciton} callback success callback
+ */
+exports.getStandardChallenges = function (list, query, callback) {
+    var url = url_standardChallenges + "/" + list,
+        queryWithDefaults = _.merge(query || {}, defaultQs);
+    
+    requestFromTC_API(url, queryWithDefaults, function (err, queryResult) {
+        if (err) {
+            callback(err);
+        } else {
+            async.map(queryResult.data
+                ,function (item, callback) {
+                    //fetch challenge details and merge the results into the current item
+                    var detailUrl = url_standardChallenges + "/" + item.challengeId;
+                    requestFromTC_API(detailUrl, null, function (err, detailsResult) {
+                        if (err) {
+                            callback(err);
+                        } else {
+                            callback(null, _.merge(item, detailsResult));
+                        }
+                    });
+                }
+                ,function(err, detailResult) {
+                    if (err) {
+                        callback(err);
+                    } else {
+                        queryResult.data = detailResult;
+                        callback(null, queryResult);
+                    }
+                }
+            );
+        }
+        
+    });
+}
+
+
+/**
+ * Performs a cache-first request to the topcoder "data" API for marathon matches
+ *
+ * @param {object} query 
+ * @param {funciton} callback success callback
+ */
+exports.getDataScienceChallenges = function (query, callback) {
+    var queryWithDefaults = _.merge(query || {}, defaultQs);
+    
+    requestFromTC_API(url_dataScience, queryWithDefaults, function (err, body) {
+        if (err) {
+            callback(err);
+        } else {
+            // normalize the return data so it can be consued by the feed builder
+            // more consistenly with the standard challenge data
+            body.data = _.map(body.data, function (rec) {
+                return {
+                    challengeName: rec.fullName,
+                    problemId: rec.problemId,
+                    roundId: rec.roundId,
+                    registrationStartDate: rec.startDate
+                };
+            });
+            callback(null, body);
+        }
+    });
+}


### PR DESCRIPTION
New in this version:
- For each challenge (except "data" track) we now fetch the challenge details from the TC API
- Includes 500 characters of the description in the challenge feed, and simplifies the HTML
- Includes some basic stats (prize, dates, platforms, etc)
- Uses a standard "timeout" express module
- Uses the `async` library to run parallel API calls
- Created a new input parameter `track` to help differentiate it from `challengeType` 